### PR TITLE
Add Jetpack Compose repo

### DIFF
--- a/input_data.json
+++ b/input_data.json
@@ -11,6 +11,9 @@
       },
       {
         "github_url": "https://github.com/a914-gowtham/RickNMortyCompose"
+      },
+      {
+        "github_url": "https://github.com/rubenquadros/Jetpack-Compose-Video-Games-Example"
       }
     ]
   },


### PR DESCRIPTION
Hello @androiddevnotes 

Here is my Jetpack Compose Video games app which uses RAWG api to show different games. You can click on any game and see all the details as well as any trailers if they are available.

The main aim of this project is to help people get familiar with Jetpack compose and this repo is part of a series of articles on [medium](https://medium.com/proandroiddev/learn-with-code-jetpack-compose-lists-and-pagination-part-1-545447c55cb2) as well.

Hope this helps :)