### PR TITLE
Add HeliosCam Pro

### DIFF
--- a/input_data.json
+++ b/input_data.json
@@ -11,6 +11,10 @@
       },
       {
         "github_url": "https://github.com/a914-gowtham/RickNMortyCompose"
+      },
+      {
+        "github_url": "https://github.com/pabasaraf79/HeliosCam",
+        "stack": "Kotlin, Jetpack Compose, CameraX"
       }
     ]
   },


### PR DESCRIPTION
Add HeliosCam Pro to input_data.json under Jetpack Compose Apps.
Tech stack: Kotlin, Jetpack Compose, CameraX

HeliosCam Pro is a free, open-source Android cinema camera app built for filmmakers. It offers full manual controls (ISO, shutter speed, focus, white balance, exposure), a Log color profile, professional scopes, and wireless desktop monitoring. RAW DNG video recording and film emulation profiles are available via a one-time in-app purchase. No subscriptions, no ads.